### PR TITLE
Repair source line remapping

### DIFF
--- a/src/main/java/com/github/zomboiddecompiler/LineRemapper.java
+++ b/src/main/java/com/github/zomboiddecompiler/LineRemapper.java
@@ -26,9 +26,9 @@ package com.github.zomboiddecompiler;
 import org.objectweb.asm.*;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -46,20 +46,12 @@ public final class LineRemapper {
         assert Files.exists(file) && Files.isRegularFile(file);
 
         try {
-            ClassReader reader = new ClassReader(
-                    Files.newInputStream(file)
-            );
-            ClassWriter writer = new ClassWriter(0);
-            reader.accept(
-                    new ClassLineRemapper(
-                            Opcodes.ASM9,
-                            writer,
-                            new LineNumbers(mappings)),
-                    Opcodes.ASM9);
-
-            Files.copy(file, destination.resolveSibling(file.getFileName().toString() + ".backup"), StandardCopyOption.REPLACE_EXISTING);
-
-            Files.write(destination, writer.toByteArray());
+            try (InputStream is = Files.newInputStream(file)) {
+                ClassReader reader = new ClassReader(is);
+                ClassWriter writer = new ClassWriter(0);
+                reader.accept(new ClassLineRemapper(Opcodes.ASM9, writer, new LineNumbers(mappings)), 0);
+                Files.write(destination, writer.toByteArray());
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/zomboiddecompiler/ZomboidContextSource.java
+++ b/src/main/java/com/github/zomboiddecompiler/ZomboidContextSource.java
@@ -108,14 +108,12 @@ public class ZomboidContextSource implements IContextSource, AutoCloseable {
     }
 
     @Override
-    public void close() throws IOException {
-        this.jarFilesystem.close();
-    }
+    public void close() {}
 
-    public ZomboidContextSource(Path jar, String patterns, boolean invertPatterns) throws IOException {
+    public ZomboidContextSource(Path jar, FileSystem jarFilesystem, String patterns, boolean invertPatterns) {
         assert Files.isRegularFile(jar);
         this.jar = jar;
-        this.jarFilesystem = FileSystems.newFileSystem(jar);
+        this.jarFilesystem = jarFilesystem;
         this.invertPatterns = invertPatterns;
         this.patterns = ClassPatterns.fromString(patterns);
     }

--- a/src/main/java/com/github/zomboiddecompiler/ZomboidDecompiler.java
+++ b/src/main/java/com/github/zomboiddecompiler/ZomboidDecompiler.java
@@ -96,18 +96,18 @@ public class ZomboidDecompiler {
             }
         }
 
-        ZomboidResultSaver resultSaver = new ZomboidResultSaver(outputPath.resolve("source"), gamePath);
-
-        ZomboidContextSource gameSource;
-        ZomboidContextSource dependencySource;
+        FileSystem gameJarFilesystem;
         try {
-            gameSource = new ZomboidContextSource(gameJar, this.classPatterns, false);
-            dependencySource = new ZomboidContextSource(gameJar, this.classPatterns, true);
+            gameJarFilesystem = FileSystems.newFileSystem(gameJar);
         } catch (IOException e) {
             log.log(e);
-            log.log("Aborting decompilation due to exception while opening context source");
+            log.log("Could not open jar. Aborting decompilation.");
             return;
         }
+
+        ZomboidResultSaver resultSaver = new ZomboidResultSaver(outputPath.resolve("source"), gameJarFilesystem);
+        ZomboidContextSource gameSource = new ZomboidContextSource(gameJar, gameJarFilesystem, this.classPatterns, false);
+        ZomboidContextSource dependencySource = new ZomboidContextSource(gameJar, gameJarFilesystem, this.classPatterns, true);
 
         Decompiler.Builder builder = Decompiler.builder()
                 .inputs(gameSource)
@@ -134,13 +134,21 @@ public class ZomboidDecompiler {
             builder.option(IFabricJavadocProvider.PROPERTY_NAME, new RosettaJavadocProvider());
         }
 
-        // FIXME: this can't rewrite the jar used in 42.13+
-//        if (remapLineNumbers) {
-//            // tells the decompiler to map bytecode to decompiled source lines
-//            builder.option(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, true);
-//            // use that data to remap the line numbers in the class files
-//            resultSaver.setRemapLineNumbers(true);
-//        }
+        if (remapLineNumbers) {
+            try {
+                // back up the original jar before remapping line numbers inside it
+                Path backupJar = gameJar.resolveSibling(gameJar.getFileName() + ".backup");
+                Files.copy(gameJar, backupJar, StandardCopyOption.REPLACE_EXISTING);
+                // tells the decompiler to map bytecode to decompiled source lines
+                builder.option(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, true);
+                // use that data to remap the line numbers in the class files
+                resultSaver.setRemapLineNumbers(true);
+            }
+            catch (IOException e) {
+                log.log(e);
+                log.log("Could not create jar backup. Line remapping is cancelled.");
+            }
+        }
 
         for (VineflowerArgument argument: vineflowerArgs) {
             builder.option(argument.parameter, argument.value);
@@ -154,7 +162,7 @@ public class ZomboidDecompiler {
         log.log("Decompilation complete.");
 
         try {
-            gameSource.close();
+            gameJarFilesystem.close();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/zomboiddecompiler/ZomboidResultSaver.java
+++ b/src/main/java/com/github/zomboiddecompiler/ZomboidResultSaver.java
@@ -5,6 +5,7 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
 
 import java.io.*;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -21,12 +22,12 @@ public final class ZomboidResultSaver implements IResultSaver {
 
     /// If true, when saving a decompiled source file, the corresponding .class file will be found and its line numbers will be remapped to the source file.
     private boolean remapLineNumbers = false;
-    /// Root directory of the game (ProjectZomboid/).
-    private final Path gameRoot;
+    /// File system for accessing the game's jar archive.
+    private final FileSystem jarFilesystem;
 
-    public ZomboidResultSaver(Path root, Path gameRoot) {
+    public ZomboidResultSaver(Path root, FileSystem jarFilesystem) {
         this.root = root;
-        this.gameRoot = gameRoot;
+        this.jarFilesystem = jarFilesystem;
     }
 
     public void setRemapLineNumbers(boolean remapLineNumbers) {
@@ -95,20 +96,20 @@ public final class ZomboidResultSaver implements IResultSaver {
         // i don't really like doing this here, but i can't find another place to extract the line mappings
         // mapping length is checked so that files with no code don't get remapped, as this fails
         if (remapLineNumbers && mapping.length > 0) {
-            assert this.gameRoot != null;
-
             Map<Integer, Integer> mappingMap = new LinkedHashMap<>();
             for (int i = 0; i < mapping.length; i += 2) {
                 mappingMap.put(mapping[i], mapping[i + 1]);
             }
 
-            // this actually points to a .java file, which probably doesn't exist!!
-            Path classFile = this.gameRoot.resolve(entryName);
+            // this actually points to a .java file, which doesn't exist!!
+            Path classFile = this.jarFilesystem.getPath(entryName);
             Path classDirectory = classFile.getParent();
+            String classPath = entryName.replace(this.jarFilesystem.getSeparator(), ".");
+            classPath = classPath.substring(0, classPath.length() - ".java".length());
             String className = classFile.getFileName().toString();
             className = className.substring(0, className.length() - ".java".length());
 
-            ZomboidDecompiler.log.log("Remapping line numbers in " + className);
+            ZomboidDecompiler.log.log("Remapping line numbers in " + classPath);
 
             List<Path> files;
             try (Stream<Path> fileStream = Files.list(classDirectory)) {


### PR DESCRIPTION
Restores the `--remap-line-numbers` feature by patching classes directly in the jar. The original jar is backed up as a whole instead of creating individual backups of each patched class file.
There is also a minor fix to the `reader.accept` call: `Opcodes.ASM9` was incorrectly passed as the `parsingOptions` argument. It didn't affect anything, but it was still a bug. Replaced with zero, as in fabric-loom: https://github.com/FabricMC/fabric-loom/blob/4b0481bc9261ab8e72a435e2d8815f8cf5165f57/src/main/java/net/fabricmc/loom/decompilers/LineNumberRemapper.java#L82

#28 can be closed.

I also attempted to fix #14 as part of this PR but didn't have the problem on my side. Tested with `--class-pattern=zombie.*,se.*` using a script across all decompiled files to verify that mapped lines match real ones and didn't detect any mismatches. So this was probably a Vineflower bug that has since been fixed.